### PR TITLE
DDO-4193 read from gar

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,10 +6,7 @@ val publishPatterns = Patterns()
   .withIvyPatterns(Vector(s"$patternBase/ivy-[revision].xml"))
   .withArtifactPatterns(Vector(s"$patternBase/[module]-[revision](-[classifier]).[ext]"))
 
-resolvers += Resolver.url(
-  "Broad Artifactory",
-  new URL("https://broadinstitute.jfrog.io/broadinstitute/libs-release/")
-)(publishPatterns)
+resolvers += "Google Artifact Repository" at "https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release/"
 
 // useful when testing ingest-utils locally
 resolvers += Resolver.mavenLocal


### PR DESCRIPTION
## Why

Ticket: https://broadworkbench.atlassian.net/browse/DDO-4193

During brownout testing of artifact reads in JFrog Artifactory, we discovered there's a resolver that needs to be updated here.

This PR updates the resolver to point to Google Artifact Registry.

## This PR

## Checklist
- [ ] Documentation has been updated as needed.
